### PR TITLE
Fixing issues in Node 8.5+ -- Child process uses exec instead of spawn

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 
-const program = require('commander')
-const spawn = require('child_process').spawn;
-const package = require('../package.json');
-const chalk = require('chalk');
+const program = require("commander");
+const spawn = require("child_process").exec;
+const package = require("../package.json");
+const chalk = require("chalk");
 
-const build = require('./build');
+const build = require("./build");
 
 program
-.version(package.version)
-  .usage('<keywords>')
+  .version(package.version)
+  .usage("<keywords>")
   .parse(process.argv);
 
 if (program.args.length > 0) {
-  spawn(build(program.args[0]), { shell: true, stdio: 'inherit' });
+  exec(build(program.args[0]), { shell: true, stdio: "inherit" });
 } else if (program.args.length < 1) {
-  console.log(chalk.red('Please supply a name for your new React XP app.'));
+  console.log(chalk.red("Please supply a name for your new React XP app."));
 }


### PR DESCRIPTION
Fixes issues when running the CLI in Node 8.5+. child_process.spawn no longer accepts a function. Use exec instead. Please disregard formatting differences, I am using prettier.